### PR TITLE
Allow entering room only when in game

### DIFF
--- a/ablygamesdk/src/main/java/com/ably/game/room/AblyGame.kt
+++ b/ablygamesdk/src/main/java/com/ably/game/room/AblyGame.kt
@@ -96,6 +96,12 @@ class AblyGame private constructor(apiKey: String, val scope: CoroutineScope, ga
             continuation.resume(ably.channels[GLOBAL_CHANNEL_NAME].presence.get().size)
         }
     }
+    suspend fun allPlayers(): List<GamePlayer> {
+        return suspendCoroutine { continuation ->
+            val players = ably.channels[GLOBAL_CHANNEL_NAME].presence.get().map { DefaultGamePlayer(it.clientId) }
+            continuation.resume(players)
+        }
+    }
 
     fun subscribeToPlayerNumberUpdate(updated: (action: PresenceAction) -> Unit) {
         val observedActions = EnumSet.of(PresenceMessage.Action.enter, PresenceMessage.Action.leave)
@@ -106,5 +112,9 @@ class AblyGame private constructor(apiKey: String, val scope: CoroutineScope, ga
             }
         }
 
+    }
+
+    suspend fun isInGame(gamePlayer: GamePlayer): Boolean {
+        return allPlayers().find { it.id == gamePlayer.id } != null
     }
 }

--- a/ablygamesdk/src/main/java/com/ably/game/room/AblyGame.kt
+++ b/ablygamesdk/src/main/java/com/ably/game/room/AblyGame.kt
@@ -114,7 +114,8 @@ class AblyGame private constructor(apiKey: String, val scope: CoroutineScope, ga
 
     }
 
-    suspend fun isInGame(gamePlayer: GamePlayer): Boolean {
+    suspend fun isInGame(gamePlayer: GamePlayer?): Boolean {
+        if (gamePlayer == null) return false
         return allPlayers().find { it.id == gamePlayer.id } != null
     }
 }

--- a/app/src/main/java/com/ably/game/example/ui/MainActivity.kt
+++ b/app/src/main/java/com/ably/game/example/ui/MainActivity.kt
@@ -38,7 +38,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var roomsRecyclerView: RecyclerView
     private lateinit var numberOfPlayersTextView: TextView
     private lateinit var ablyGame: AblyGame
-    private lateinit var gamePlayer: MyGamePlayer
+    private var gamePlayer: MyGamePlayer? = null
     private lateinit var enterButton: Button
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -97,7 +97,7 @@ class MainActivity : AppCompatActivity() {
     private fun leaveGame() {
         lifecycleScope.launch {
             enterButton.isEnabled = false
-            val leaveResult = MultiplayerGameApp.instance.ablyGame.leave(gamePlayer)
+            val leaveResult = MultiplayerGameApp.instance.ablyGame.leave(gamePlayer!!)
             enterButton.isEnabled = true
             if (leaveResult.isSuccess) {
                 Log.d(TAG, "Successful leave")
@@ -112,7 +112,7 @@ class MainActivity : AppCompatActivity() {
         lifecycleScope.launch {
             //also register to changes
             enterButton.isEnabled = false
-            val enterResult = ablyGame.enter(gamePlayer)
+            val enterResult = ablyGame.enter(gamePlayer!!)
             enterButton.isEnabled = true
             if (enterResult.isSuccess) {
                 Log.d(TAG, "Successful entry")

--- a/app/src/main/java/com/ably/game/example/ui/MainActivity.kt
+++ b/app/src/main/java/com/ably/game/example/ui/MainActivity.kt
@@ -148,12 +148,20 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun onRoomTap(gameRoom: GameRoom) {
-        Intent(this, GameRoomActivity::class.java).run {
-            val gson = Gson()
-            putExtra(GameRoomActivity.EXTRA_ROOM_JSON, gson.toJson(gameRoom))
-            putExtra(GameRoomActivity.EXTRA_PLAYER_JSON, gson.toJson(gamePlayer))
-            startActivity(this)
+        val context = this
+        lifecycleScope.launch {
+            if (!ablyGame.isInGame(gamePlayer)) {
+                Toast.makeText(context, "You need to enter game first", Toast.LENGTH_SHORT).show()
+                return@launch
+            }
+            Intent(context, GameRoomActivity::class.java).run {
+                val gson = Gson()
+                putExtra(GameRoomActivity.EXTRA_ROOM_JSON, gson.toJson(gameRoom))
+                putExtra(GameRoomActivity.EXTRA_PLAYER_JSON, gson.toJson(gamePlayer))
+                startActivity(this)
+            }
         }
+
 
     }
 }


### PR DESCRIPTION
This PR improves example app and SDK 

* Adds new methods to Ably Game to check current players in game and whether a player is already in a game
* Only allows entry to the room if a player is already in the game